### PR TITLE
Bicaws7 3717 create prototype for new feedback page

### DIFF
--- a/login/app/routes.js
+++ b/login/app/routes.js
@@ -33,10 +33,14 @@ router.post("/security-code", function (request, response) {
   return response.render("/security-code", { incorrectSecurityCode: true });
 });
 
-router.post("/feedback-response", function (request, response) {
+router.post("/feedback", function (request, response) {
   const satisfactionRating = request.body.satisfactionRating;
-  if (!satisfactionRating) {
-    return response.render("/feedback", { radioEmpty: true });
+  const improvementSuggestion = request.body.improvementSuggestion;
+  isRadioEmpty = !satisfactionRating;
+  isSuggestionEmpty = improvementSuggestion === "";
+
+  if (isRadioEmpty || isSuggestionEmpty) {
+    return response.render("/feedback", { isRadioEmpty, isSuggestionEmpty });
   }
   return response.redirect("/welcome");
 });

--- a/login/app/routes.js
+++ b/login/app/routes.js
@@ -28,6 +28,7 @@ router.post("/security-code", function (request, response) {
   const correctSecurityCode = "1234";
   const { securityCode } = request.body;
   if (securityCode === correctSecurityCode) {
+    request.session.data.isLoggedIn = true;
     return response.redirect("/welcome");
   }
   return response.render("/security-code", { incorrectSecurityCode: true });
@@ -42,5 +43,9 @@ router.post("/feedback", function (request, response) {
   if (isRadioEmpty || isSuggestionEmpty) {
     return response.render("/feedback", { isRadioEmpty, isSuggestionEmpty });
   }
-  return response.redirect("/welcome");
+  const isLoggedIn = request.session.data.isLoggedIn;
+  if (isLoggedIn) {
+    return response.redirect("/welcome");
+  }
+  return response.redirect("/sign-in");
 });

--- a/login/app/routes.js
+++ b/login/app/routes.js
@@ -47,5 +47,13 @@ router.post("/feedback", function (request, response) {
   if (isLoggedIn) {
     return response.redirect("/welcome");
   }
+  return response.redirect("/feedback-confirmation");
+});
+
+router.post("/feedback-confirmation", function (request, response) {
+  const isLoggedIn = request.session.data.isLoggedIn;
+  if (isLoggedIn) {
+    return response.redirect("/welcome");
+  }
   return response.redirect("/sign-in");
 });

--- a/login/app/routes.js
+++ b/login/app/routes.js
@@ -32,3 +32,11 @@ router.post("/security-code", function (request, response) {
   }
   return response.render("/security-code", { incorrectSecurityCode: true });
 });
+
+router.post("/feedback-response", function (request, response) {
+  const satisfactionRating = request.body.satisfactionRating;
+  if (!satisfactionRating) {
+    return response.render("/feedback", { radioEmpty: true });
+  }
+  return response.redirect("/welcome");
+});

--- a/login/app/views/feedback-confirmation.html
+++ b/login/app/views/feedback-confirmation.html
@@ -1,0 +1,44 @@
+{% extends "layouts/main.html" %} {% block pageTitle %} GOV.UK page template –
+{{ serviceName }} – GOV.UK Prototype Kit {% endblock %} {% block content %}
+<div class="govuk-grid-row">
+  <div class="govuk-phase-banner govuk-!-margin-bottom-5">
+    <p class="govuk-phase-banner__content">
+      <strong class="govuk-tag govuk-phase-banner__content__tag"> Beta </strong>
+      <span class="govuk-phase-banner__text">
+        This is a new service - your
+        <a
+          class="govuk-link"
+          href="/feedback"
+          rel="noreferrer noopener"
+          target="_blank"
+          >feedback</a
+        >
+        will help us improve it (opens in new window)
+      </span>
+    </p>
+  </div>
+
+  <div class="govuk-grid-column-two-thirds">
+    <h1 class="govuk-heading-l">Thank you for your feedback</h1>
+    <p class="govuk-body">
+      Your feedback will help us make improvements to Bichard7.
+    </p>
+    <form method="POST" action="/feedback-confirmation">
+      <button type="submit" class="govuk-button" data-module="govuk-button">
+        Return to Bichard7
+      </button>
+    </form>
+    <p class="govuk-body">
+      <a
+        href="/help"
+        class="govuk-link govuk-link--no-underline govuk-!-font-weight-bold"
+        rel="noreferrer noopener"
+        target="_blank"
+      >
+        Get help with this page (new window)
+      </a>
+    </p>
+  </div>
+</div>
+
+{% endblock %}

--- a/login/app/views/feedback.html
+++ b/login/app/views/feedback.html
@@ -92,7 +92,9 @@
         </fieldset>
       </div>
       <div
-        class="govuk-form-group {% if isSuggestionEmpty %}govuk-form-group--error{% endif %}"
+        class="govuk-form-group govuk-character-count {% if isSuggestionEmpty %}govuk-form-group--error{% endif %}"
+        data-module="govuk-character-count"
+        data-maxwords="150"
       >
         <label
           class="govuk-label govuk-!-font-weight-bold"
@@ -100,24 +102,37 @@
         >
           How can we improve Bichard7?
         </label>
-        <div id="more-detail-hint" class="govuk-hint">
+
+        <div id="improvementSuggestion-hint" class="govuk-hint">
           Do not include any personal or case information, for example your
           name, email address, force or case details
         </div>
+
         {% if isSuggestionEmpty %}
-        <p id="whereDoYouLive-error" class="govuk-error-message">
-          <span class="govuk-visually-hidden">Error:</span> Mandatory field
+        <p id="improvementSuggestion-error" class="govuk-error-message">
+          <span class="govuk-visually-hidden">Error:</span> Enter your
+          suggestions
         </p>
         {% endif %}
+
         <textarea
-          class="govuk-textarea"
+          class="govuk-textarea govuk-js-character-count"
           id="improvementSuggestion"
           name="improvementSuggestion"
           rows="5"
-          value=
-        >{{ data['improvementSuggestion']}}
-        </textarea>
+          aria-describedby="improvementSuggestion-hint improvementSuggestion-info"
+        >
+{{ data['improvementSuggestion'] | escape }}</textarea
+        >
+
+        <div
+          id="improvementSuggestion-info"
+          class="govuk-hint govuk-character-count__message"
+        >
+          You can enter up to 150 words
+        </div>
       </div>
+
       {{ govukButton({ text: "Submit" }) }}
     </form>
     <p class="govuk-body">

--- a/login/app/views/feedback.html
+++ b/login/app/views/feedback.html
@@ -1,0 +1,116 @@
+{% extends "layouts/main.html" %} {% block pageTitle %} Question page template –
+{{ serviceName }} – GOV.UK Prototype Kit {% endblock %} {% block beforeContent
+%} {% endblock %} {% block content %}
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h1 class="govuk-heading-l">Share your feedback</h1>
+    <p class="govuk-body">
+      Please tell us about your experience of using Bichard7.
+    </p>
+    <p class="govuk-body">
+      Your responses are anonymous and are used to make future improvements.
+    </p>
+    <p class="govuk-body">
+      We do not reply to feedback. If you need support with your account contact
+      your User Manager.
+    </p>
+    <form class="form" action="/feedback-response" method="post">
+      <div
+        class="govuk-form-group {% if radioEmpty %}govuk-form-group--error{% endif %}"
+      >
+        <fieldset class="govuk-fieldset">
+          <legend class="govuk-fieldset__legend govuk-!-font-weight-bold">
+            Overall, how did you feel about using Bichard7 today?
+          </legend>
+          {% if radioEmpty %}
+          <p id="whereDoYouLive-error" class="govuk-error-message">
+            <span class="govuk-visually-hidden">Error:</span> Select one option
+          </p>
+          {% endif %}
+          <div class="govuk-radios" data-module="govuk-radios">
+            <div class="govuk-radios__item">
+              <input
+                class="govuk-radios__input"
+                id="satisfactionRating"
+                name="satisfactionRating"
+                type="radio"
+                value="very-satisfied"
+              />
+              <label
+                class="govuk-label govuk-radios__label"
+                for="satisfactionRating"
+              >
+                Very satisfied
+              </label>
+            </div>
+            <div class="govuk-radios__item">
+              <input
+                class="govuk-radios__input"
+                id="satisfactionRating-2"
+                name="satisfactionRating"
+                type="radio"
+                value="satisfied"
+              />
+              <label
+                class="govuk-label govuk-radios__label"
+                for="satisfactionRating-2"
+              >
+                Satisfied
+              </label>
+            </div>
+            <div class="govuk-radios__item">
+              <input
+                class="govuk-radios__input"
+                id="satisfactionRating-3"
+                name="satisfactionRating"
+                type="radio"
+                value="neither-satisfied-or-dissatisfied"
+              />
+              <label
+                class="govuk-label govuk-radios__label"
+                for="satisfactionRating-3"
+              >
+                Neither satisfied or dissatisfied
+              </label>
+            </div>
+            <div class="govuk-radios__item">
+              <input
+                class="govuk-radios__input"
+                id="satisfactionRating-4"
+                name="satisfactionRating"
+                type="radio"
+                value="dissatisfied"
+              />
+              <label
+                class="govuk-label govuk-radios__label"
+                for="satisfactionRating-4"
+              >
+                Dissatisfied
+              </label>
+            </div>
+            <div class="govuk-radios__item">
+              <input
+                class="govuk-radios__input"
+                id="satisfactionRating-5"
+                name="satisfactionRating"
+                type="radio"
+                value="very-satisfied"
+              />
+              <label
+                class="govuk-label govuk-radios__label"
+                for="satisfactionRating-5"
+              >
+                Very dissatisfied
+              </label>
+            </div>
+          </div>
+        </fieldset>
+      </div>
+
+      {{ govukButton({ text: "Submit" }) }}
+    </form>
+  </div>
+</div>
+
+{% endblock %}

--- a/login/app/views/feedback.html
+++ b/login/app/views/feedback.html
@@ -15,15 +15,15 @@
       We do not reply to feedback. If you need support with your account contact
       your User Manager.
     </p>
-    <form class="form" action="/feedback-response" method="post">
+    <form class="form" action="/feedback" method="post">
       <div
-        class="govuk-form-group {% if radioEmpty %}govuk-form-group--error{% endif %}"
+        class="govuk-form-group {% if isRadioEmpty %}govuk-form-group--error{% endif %}"
       >
         <fieldset class="govuk-fieldset">
           <legend class="govuk-fieldset__legend govuk-!-font-weight-bold">
             Overall, how did you feel about using Bichard7 today?
           </legend>
-          {% if radioEmpty %}
+          {% if isRadioEmpty %}
           <p id="whereDoYouLive-error" class="govuk-error-message">
             <span class="govuk-visually-hidden">Error:</span> Select one option
           </p>
@@ -107,9 +107,43 @@
           </div>
         </fieldset>
       </div>
-
+      <div
+        class="govuk-form-group {% if isSuggestionEmpty %}govuk-form-group--error{% endif %}"
+      >
+        <label
+          class="govuk-label govuk-!-font-weight-bold"
+          for="improvementSuggestion"
+        >
+          How can we improve Bichard7?
+        </label>
+        <div id="more-detail-hint" class="govuk-hint">
+          Do not include any personal or case information, for example your
+          name, email address, force or case details
+        </div>
+        {% if isSuggestionEmpty %}
+        <p id="whereDoYouLive-error" class="govuk-error-message">
+          <span class="govuk-visually-hidden">Error:</span> Mandatory field
+        </p>
+        {% endif %}
+        <textarea
+          class="govuk-textarea"
+          id="improvementSuggestion"
+          name="improvementSuggestion"
+          rows="5"
+        ></textarea>
+      </div>
       {{ govukButton({ text: "Submit" }) }}
     </form>
+    <p class="govuk-body">
+      <a
+        href="/help"
+        class="govuk-link govuk-link--no-underline govuk-!-font-weight-bold"
+        rel="noreferrer noopener"
+        target="_blank"
+      >
+        Get help with this page (new window)
+      </a>
+    </p>
   </div>
 </div>
 

--- a/login/app/views/feedback.html
+++ b/login/app/views/feedback.html
@@ -30,13 +30,10 @@
           {% endif %}
           <div class="govuk-radios" data-module="govuk-radios">
             <div class="govuk-radios__item">
-              <input
-                class="govuk-radios__input"
-                id="satisfactionRating"
-                name="satisfactionRating"
-                type="radio"
-                value="very-satisfied"
-              />
+              <input class="govuk-radios__input" id="satisfactionRating"
+              name="satisfactionRating" type="radio" value="very-satisfied" {%
+              if data['satisfactionRating'] == "very-satisfied" %}checked{%
+              endif %}>
               <label
                 class="govuk-label govuk-radios__label"
                 for="satisfactionRating"
@@ -45,13 +42,9 @@
               </label>
             </div>
             <div class="govuk-radios__item">
-              <input
-                class="govuk-radios__input"
-                id="satisfactionRating-2"
-                name="satisfactionRating"
-                type="radio"
-                value="satisfied"
-              />
+              <input class="govuk-radios__input" id="satisfactionRating-2"
+              name="satisfactionRating" type="radio" value="satisfied" {% if
+              data['satisfactionRating'] == "satisfied" %}checked{% endif %}>
               <label
                 class="govuk-label govuk-radios__label"
                 for="satisfactionRating-2"
@@ -60,13 +53,11 @@
               </label>
             </div>
             <div class="govuk-radios__item">
-              <input
-                class="govuk-radios__input"
-                id="satisfactionRating-3"
-                name="satisfactionRating"
-                type="radio"
-                value="neither-satisfied-or-dissatisfied"
-              />
+              <input class="govuk-radios__input" id="satisfactionRating-3"
+              name="satisfactionRating" type="radio"
+              value="neither-satisfied-or-dissatisfied" {% if
+              data['satisfactionRating'] == "neither-satisfied-or-dissatisfied"
+              %}checked{% endif %}>
               <label
                 class="govuk-label govuk-radios__label"
                 for="satisfactionRating-3"
@@ -75,13 +66,9 @@
               </label>
             </div>
             <div class="govuk-radios__item">
-              <input
-                class="govuk-radios__input"
-                id="satisfactionRating-4"
-                name="satisfactionRating"
-                type="radio"
-                value="dissatisfied"
-              />
+              <input class="govuk-radios__input" id="satisfactionRating-4"
+              name="satisfactionRating" type="radio" value="dissatisfied" {% if
+              data['satisfactionRating'] == "dissatisfied" %}checked{% endif %}>
               <label
                 class="govuk-label govuk-radios__label"
                 for="satisfactionRating-4"
@@ -90,13 +77,10 @@
               </label>
             </div>
             <div class="govuk-radios__item">
-              <input
-                class="govuk-radios__input"
-                id="satisfactionRating-5"
-                name="satisfactionRating"
-                type="radio"
-                value="very-satisfied"
-              />
+              <input class="govuk-radios__input" id="satisfactionRating-5"
+              name="satisfactionRating" type="radio" value="very-dissatisfied"
+              {% if data['satisfactionRating'] == "very-dissatisfied"
+              %}checked{% endif %}>
               <label
                 class="govuk-label govuk-radios__label"
                 for="satisfactionRating-5"
@@ -130,7 +114,9 @@
           id="improvementSuggestion"
           name="improvementSuggestion"
           rows="5"
-        ></textarea>
+          value=
+        >{{ data['improvementSuggestion']}}
+        </textarea>
       </div>
       {{ govukButton({ text: "Submit" }) }}
     </form>

--- a/login/app/views/feedback.html
+++ b/login/app/views/feedback.html
@@ -3,7 +3,7 @@
 %} {% endblock %} {% block content %}
 
 <div class="govuk-grid-row">
-  <div class="govuk-grid-column-two-thirds">
+  <div class="govuk-grid-column">
     <h1 class="govuk-heading-l">Share your feedback</h1>
     <p class="govuk-body">
       Please tell us about your experience of using Bichard7.


### PR DESCRIPTION
Add new feedback page to prototype that can be accessed from beta banner.

Add mandatory fields to feedback page about user satisfaction and suggestions for improvement. 
Error messages appear when fields are left empty.
Text input area has word limit counter, but it doesn't stop users from submitting text that is over the limit.
When submitting the form the user is redirected to the feedback-confirmation page.
Feedback-confirmation page redirects users to login page or welcome page based on whether they're logged in or not.